### PR TITLE
Clarify DbContext configuration method with comment

### DIFF
--- a/CarSpot.Infrastructure/Persistence/Context/ApplicationDbContext.cs
+++ b/CarSpot.Infrastructure/Persistence/Context/ApplicationDbContext.cs
@@ -20,6 +20,7 @@ public class ApplicationDbContext : DbContext
         _domainEventsInterceptor = domainEventsInterceptor;
 
     }
+    // Configure the DbContext
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder.AddInterceptors(_domainEventsInterceptor);

--- a/CarSpot.Infrastructure/Persistence/Repositories/ListingStatusRepository.cs
+++ b/CarSpot.Infrastructure/Persistence/Repositories/ListingStatusRepository.cs
@@ -1,11 +1,7 @@
 using CarSpot.Application.Interfaces;
 using CarSpot.Domain.Entities;
-using CarSpot.Infrastructure.Persistence;
 using CarSpot.Infrastructure.Persistence.Context;
 using Microsoft.EntityFrameworkCore;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using CarSpot.Infrastructure.Persistence.Repositories;
 
 namespace CarSpot.Infrastructure.Persistence.Repositories
 {


### PR DESCRIPTION
Add a comment to the DbContext configuration method to enhance clarity and understanding of its purpose.