### PR TITLE
Remove unused using directives in VehicleImageRepository.cs

### DIFF
--- a/CarSpot.Infrastructure/Persistence/Repositories/VehicleImageRepository.cs
+++ b/CarSpot.Infrastructure/Persistence/Repositories/VehicleImageRepository.cs
@@ -1,10 +1,6 @@
-using CarSpot.Domain.Entities;
-using CarSpot.Domain.Common;
 using CarSpot.Application.Interfaces;
 using CarSpot.Infrastructure.Persistence.Context;
-using CarSpot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
 namespace CarSpot.Infrastructure.Repositories
 {


### PR DESCRIPTION
Eliminate unnecessary using directives to clean up the code in VehicleImageRepository.cs.