### PR TITLE
Remove unused using directive in ListingStatusController

### DIFF
--- a/CarSpot.WebApi/Controllers/ListingStatusController.cs
+++ b/CarSpot.WebApi/Controllers/ListingStatusController.cs
@@ -3,7 +3,6 @@ using CarSpot.Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using CarSpot.Infrastructure.Persistence.Repositories;
 
 
 


### PR DESCRIPTION
Eliminate an unnecessary using directive to clean up the code in ListingStatusController.