### PR TITLE
Remove unused using directive in CommentsController

### DIFF
--- a/CarSpot.WebApi/Controllers/CommentsController.cs
+++ b/CarSpot.WebApi/Controllers/CommentsController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using CarSpot.Domain.Entities;
 using CarSpot.Application.Interfaces.Repositories;
 
 namespace CarSpot.WebApi.Controllers


### PR DESCRIPTION
Eliminate an unnecessary using directive for CarSpot.Domain.Entities in the CommentsController file.